### PR TITLE
(optional) Disable system UI for the constellation vignette

### DIFF
--- a/vignettes/constellations_list/lib/main.dart
+++ b/vignettes/constellations_list/lib/main.dart
@@ -1,7 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:shared/env.dart';
 
 import 'demo.dart';
-import 'package:flutter/material.dart';
 
 void main() => runApp(App());
 


### PR DESCRIPTION
This could be applied in other vignettes, but for the constellation_list vignette, and for the set up we have at Flutter Interact (with Pixel Slate), this is an especially noticeable improvement.