### PR TITLE
doc: adapting flutter package install cmd

### DIFF
--- a/vignettes/indie_3d/README.md
+++ b/vignettes/indie_3d/README.md
@@ -25,7 +25,7 @@ In addition to reviewing and forking the [MIT-licensed](LICENSE.md) code availab
 
 If you're new to Flutter the first thing you'll need is to follow the [setup instructions](https://flutter.dev/docs/get-started/install). Once you're set up and can compile the sample Flutter app, you're ready to run some vignettes!
 
-Each vignette is stored in its own folder in the repository. Using your IDE of choice, open the vignette directory you'd like to run. Then, using the terminal inside youre IDE, run `flutter get` to fetch any dependencies, and `flutter run` to deploy to your connected device or simulator.
+Each vignette is stored in its own folder in the repository. Using your IDE of choice, open the vignette directory you'd like to run. Then, using the terminal inside youre IDE, run `flutter packages get` to fetch any dependencies, and `flutter run` to deploy to your connected device or simulator.
 
 If you would like to try these for Flutter for web, you can use `flutter run -d chrome`. Note that Flutter for web is currently a technical preview and not all of the vignettes will work correctly. For more information on enabling Flutter for web follow the [setup instructions](https://flutter.dev/docs/get-started/web).
 


### PR DESCRIPTION
```bash
$ flutter get
Could not find a command named "get".
Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
```